### PR TITLE
Updates high-performance endpoint to cdn-api.ooyala.com

### DIFF
--- a/gem-ooyala-v2-api/lib/ooyala-v2-api.rb
+++ b/gem-ooyala-v2-api/lib/ooyala-v2-api.rb
@@ -54,14 +54,14 @@ module Ooyala
   class API
     SUPPORTED_HTTP_METHODS    = %w{GET POST PUT PATCH DELETE}
     DEFAULT_BASE_URL          = 'https://api.ooyala.com'
-    DEFAULT_CACHE_BASE_URL    = 'https://cdn.api.ooyala.com'
+    DEFAULT_CACHE_BASE_URL    = 'https://cdn-api.ooyala.com'
     DEFAULT_EXPIRATION_WINDOW = 15
     ROUND_UP_TIME             = 300
 
     # Sets the String base URL (default: "https://api.ooyala.com").
     attr_writer :base_url
 
-    # Sets the String cache base URL (default: "https://cdn.api.ooyala.com").
+    # Sets the String cache base URL (default: "https://cdn-api.ooyala.com").
     attr_writer :cache_base_url
 
     # Sets the Number with the expiration window. This is added to the current

--- a/gem-ooyala-v2-api/test/test_ooyala-v2-api.rb
+++ b/gem-ooyala-v2-api/test/test_ooyala-v2-api.rb
@@ -53,7 +53,7 @@ class TestOoyalaV2Api < Test::Unit::TestCase
 
   def test_build_url
     url = @ooyala_api.build_url 'GET', '/v2/players/HbxJKM'
-    assert url.include?('https://cdn.api.ooyala.com/')
+    assert url.include?('https://cdn-api.ooyala.com/')
     assert url.include?('/v2/players/HbxJKM')
     url = @ooyala_api.build_url 'POST', '/v2/players/HbxJKM',
       {:test => true, 'a' => 'b'}
@@ -101,7 +101,7 @@ class TestOoyalaV2Api < Test::Unit::TestCase
     res = RestClient::Response
     mock(RestClient::Request).new.with_any_args do |*args|
       assert args.first[:url].include?(
-        "https://cdn.api.ooyala.com/v2/players/HbxJKM")
+        "https://cdn-api.ooyala.com/v2/players/HbxJKM")
       assert args.first[:url].include?("test=%27tr+ue%27")
       assert args.first[:url].include?("other=1")
       req
@@ -117,7 +117,7 @@ class TestOoyalaV2Api < Test::Unit::TestCase
     res = RestClient::Response
     mock(RestClient::Request).new.with_any_args do |*args|
       assert args.first[:url].include?(
-        "https://cdn.api.ooyala.com/v2/players/HbxJKM")
+        "https://cdn-api.ooyala.com/v2/players/HbxJKM")
       req
     end
     mock(req).execute { res }

--- a/ooyala_api.rb
+++ b/ooyala_api.rb
@@ -55,14 +55,14 @@ module Ooyala
   class API
     SUPPORTED_HTTP_METHODS    = %w{GET POST PUT PATCH DELETE}
     DEFAULT_BASE_URL          = 'https://api.ooyala.com'
-    DEFAULT_CACHE_BASE_URL    = 'https://cdn.api.ooyala.com'
+    DEFAULT_CACHE_BASE_URL    = 'https://cdn-api.ooyala.com'
     DEFAULT_EXPIRATION_WINDOW = 15
     ROUND_UP_TIME             = 300
 
     # Sets the String base URL (default: "https://api.ooyala.com").
     attr_writer :base_url
 
-    # Sets the String cache base URL (default: "https://cdn.api.ooyala.com").
+    # Sets the String cache base URL (default: "https://cdn-api.ooyala.com").
     attr_writer :cache_base_url
 
     # Sets the Number with the expiration window. This is added to the current

--- a/test/test_ooyala_api.rb
+++ b/test/test_ooyala_api.rb
@@ -52,7 +52,7 @@ class TestOoyalaApi < Test::Unit::TestCase
 
   def test_build_url
     url = @ooyala_api.build_url 'GET', '/v2/players/HbxJKM'
-    assert url.include?('https://cdn.api.ooyala.com/')
+    assert url.include?('https://cdn-api.ooyala.com/')
     assert url.include?('/v2/players/HbxJKM')
     url = @ooyala_api.build_url 'POST', '/v2/players/HbxJKM',
       {:test => true, 'a' => 'b'}
@@ -100,7 +100,7 @@ class TestOoyalaApi < Test::Unit::TestCase
     res = RestClient::Response
     mock(RestClient::Request).new.with_any_args do |*args|
       assert args.first[:url].include?(
-        "https://cdn.api.ooyala.com/v2/players/HbxJKM")
+        "https://cdn-api.ooyala.com/v2/players/HbxJKM")
       assert args.first[:url].include?("test=%27tr+ue%27")
       assert args.first[:url].include?("other=1")
       req
@@ -116,7 +116,7 @@ class TestOoyalaApi < Test::Unit::TestCase
     res = RestClient::Response
     mock(RestClient::Request).new.with_any_args do |*args|
       assert args.first[:url].include?(
-        "https://cdn.api.ooyala.com/v2/players/HbxJKM")
+        "https://cdn-api.ooyala.com/v2/players/HbxJKM")
       req
     end
     mock(req).execute { res }


### PR DESCRIPTION
Prior to this update, used cdn.api.ooyala.com, which did not have a valid SSL certificate.
http://support.ooyala.com/developers/documentation/concepts/api_high_performance.html
