### PR TITLE
Update rest-client to 1.8.0 for two CVE's

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :rubygems
 
-gem 'rest-client'
-gem 'json', '~> 1.6.5'
+gem 'rest-client', '~> 1.8'
+gem 'json', '~> 1.8', '>= 1.8.3'
 
 group :test do
   gem 'rr', '~> 1.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,16 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    json (1.6.8)
-    mime-types (2.3)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    json (1.8.6)
+    mime-types (2.99.3)
     multi_json (1.10.1)
-    netrc (0.7.7)
-    rest-client (1.7.2)
+    netrc (0.11.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rr (1.0.5)
@@ -13,12 +18,18 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  json (~> 1.6.5)
-  rest-client
+  json (~> 1.8, >= 1.8.3)
+  rest-client (~> 1.8)
   rr (~> 1.0.4)
   simplecov (~> 0.6.1)
+
+BUNDLED WITH
+   1.14.6

--- a/gem-ooyala-v2-api/ooyala-v2-api.gemspec
+++ b/gem-ooyala-v2-api/ooyala-v2-api.gemspec
@@ -40,34 +40,28 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<rdoc>, [">= 0"])
       s.add_runtime_dependency(%q<rake>, [">= 0"])
-      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6.6"])
+      s.add_runtime_dependency(%q<rest-client>, ["~> 1.8.0"])
       s.add_runtime_dependency(%q<json>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<tomdoc>, [">= 0"])
-      s.add_runtime_dependency(%q<json>, [">= 0"])
-      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6.6"])
     else
       s.add_dependency(%q<rdoc>, [">= 0"])
       s.add_dependency(%q<rake>, [">= 0"])
-      s.add_dependency(%q<rest-client>, ["~> 1.6.6"])
+      s.add_dependency(%q<rest-client>, ["~> 1.8.0"])
       s.add_dependency(%q<json>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_dependency(%q<tomdoc>, [">= 0"])
-      s.add_dependency(%q<json>, [">= 0"])
-      s.add_dependency(%q<rest-client>, ["~> 1.6.6"])
     end
   else
     s.add_dependency(%q<rdoc>, [">= 0"])
     s.add_dependency(%q<rake>, [">= 0"])
-    s.add_dependency(%q<rest-client>, ["~> 1.6.6"])
+    s.add_dependency(%q<rest-client>, ["~> 1.8.0"])
     s.add_dependency(%q<json>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.4"])
     s.add_dependency(%q<tomdoc>, [">= 0"])
-    s.add_dependency(%q<json>, [">= 0"])
-    s.add_dependency(%q<rest-client>, ["~> 1.6.6"])
   end
 end
 


### PR DESCRIPTION
I updated rest-client, a dependency of this gem, to 1.8.0 to fix two vulnerabilities.

```
Name: rest-client
Version: 1.6.7
Advisory: CVE-2015-1820
Criticality: Unknown
URL: https://github.com/rest-client/rest-client/issues/369
Title: rubygem-rest-client: session fixation vulnerability via
Set-Cookie headers in 30x redirection responses
Solution: upgrade to >= 1.8.0

Name: rest-client
Version: 1.6.7
Advisory: CVE-2015-3448
Criticality: Unknown
URL: http://www.osvdb.org/show/osvdb/117461
Title: Rest-Client Gem for Ruby logs password information in plaintext
Solution: upgrade to >= 1.7.3
```

Please let me know if this PR needs further edits.